### PR TITLE
Add live news via RSS feed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import Homepage from './pages/Homepage';
 import Calculator from './pages/Calculator';
+import NewsPage from './pages/NewsPage';
 import NewsletterModal from './components/NewsletterModal';
 
 function App() {
@@ -23,14 +24,7 @@ function App() {
           </div>
         );
       case 'news':
-        return (
-          <div className="min-h-screen pt-20 px-4">
-            <div className="max-w-4xl mx-auto py-12">
-              <h1 className="text-3xl font-bold text-gray-900 mb-8">Latest News</h1>
-              <p className="text-gray-600">News archive coming soon...</p>
-            </div>
-          </div>
-        );
+        return <NewsPage />;
       default:
         return <Homepage onNavigate={setCurrentPage} onShowNewsletter={() => setShowNewsletterModal(true)} />;
     }

--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -1,0 +1,43 @@
+export interface NewsItem {
+  id: string;
+  title: string;
+  link: string;
+  source: string;
+  timestamp: string;
+  excerpt: string;
+}
+
+function timeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+export async function fetchNews(limit = 5): Promise<NewsItem[]> {
+  const rssUrl = 'https://news.google.com/rss/search?q=vietnam+us+tariff';
+  const response = await fetch(
+    `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(rssUrl)}`
+  );
+  if (!response.ok) {
+    throw new Error('Failed to fetch news');
+  }
+  const data = await response.json();
+  return data.items.slice(0, limit).map((item: any, index: number) => {
+    const [titlePart, sourcePart] = item.title.split(' - ');
+    const excerpt = String(item.description ?? '').replace(/<[^>]*>/g, '').trim();
+    return {
+      id: item.guid ?? index.toString(),
+      title: titlePart ?? item.title,
+      link: item.link,
+      source: sourcePart ?? 'Unknown',
+      timestamp: timeAgo(item.pubDate),
+      excerpt,
+    } as NewsItem;
+  });
+}

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ArrowRight, Newspaper, Calculator, BookOpen, Mail, Clock, ExternalLink } from 'lucide-react';
+import { fetchNews, NewsItem } from '../data/news';
 
 interface HomepageProps {
   onNavigate: (page: string) => void;
@@ -7,43 +8,15 @@ interface HomepageProps {
 }
 
 const Homepage: React.FC<HomepageProps> = ({ onNavigate, onShowNewsletter }) => {
-  const newsItems = [
-    {
-      id: 1,
-      title: "US Announces New Tariff Framework for Vietnamese Textiles",
-      source: "Trade.gov",
-      timestamp: "2 hours ago",
-      excerpt: "New regulations expected to impact textile imports by 15% starting Q2 2025..."
-    },
-    {
-      id: 2,
-      title: "Vietnam Electronics Sector Responds to Tariff Changes",
-      source: "VietnamNews",
-      timestamp: "5 hours ago",
-      excerpt: "Local manufacturers adapt pricing strategies amid shifting trade policies..."
-    },
-    {
-      id: 3,
-      title: "Bilateral Trade Agreement Updates: What Importers Need to Know",
-      source: "CBP",
-      timestamp: "1 day ago",
-      excerpt: "Critical updates to documentation requirements for cross-border commerce..."
-    },
-    {
-      id: 4,
-      title: "Q4 Tariff Impact Analysis: Winners and Losers",
-      source: "TradeInsight",
-      timestamp: "2 days ago",
-      excerpt: "Comprehensive analysis of how recent tariff changes affected different sectors..."
-    },
-    {
-      id: 5,
-      title: "New HS Code Classifications for Tech Products",
-      source: "WTO",
-      timestamp: "3 days ago",
-      excerpt: "Updated harmonized system codes affect tariff calculations for tech imports..."
-    }
-  ];
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
+
+  useEffect(() => {
+    fetchNews(5)
+      .then(setNewsItems)
+      .catch((err) => {
+        console.error('Error fetching news', err);
+      });
+  }, []);
 
   const features = [
     {
@@ -127,10 +100,15 @@ const Homepage: React.FC<HomepageProps> = ({ onNavigate, onShowNewsletter }) => 
                 <p className="text-gray-600 mb-4 leading-relaxed">
                   {item.excerpt}
                 </p>
-                <button className="text-teal-700 font-medium text-sm hover:text-teal-800 transition-colors flex items-center group">
+                <a
+                  href={item.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-teal-700 font-medium text-sm hover:text-teal-800 transition-colors flex items-center group"
+                >
                   Read more
                   <ExternalLink className="ml-1 h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
-                </button>
+                </a>
               </article>
             ))}
           </div>

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { Clock, ExternalLink } from 'lucide-react';
+import { fetchNews, NewsItem } from '../data/news';
+
+const NewsPage: React.FC = () => {
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
+
+  useEffect(() => {
+    fetchNews(20)
+      .then(setNewsItems)
+      .catch((err) => {
+        console.error('Error fetching news', err);
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen pt-20 pb-16 bg-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">Latest News</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {newsItems.map((item) => (
+            <article
+              key={item.id}
+              className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-all duration-200 hover:border-teal-200"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-teal-100 text-teal-800">
+                  {item.source}
+                </span>
+                <div className="flex items-center text-sm text-gray-500">
+                  <Clock className="h-4 w-4 mr-1" />
+                  {item.timestamp}
+                </div>
+              </div>
+              <h2 className="text-lg font-semibold text-gray-900 mb-2 leading-tight">
+                {item.title}
+              </h2>
+              <p className="text-gray-600 mb-4 leading-relaxed">{item.excerpt}</p>
+              <a
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-teal-700 font-medium text-sm hover:text-teal-800 transition-colors flex items-center group"
+              >
+                Read more
+                <ExternalLink className="ml-1 h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
+              </a>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewsPage;


### PR DESCRIPTION
## Summary
- fetch real-time tariff news from Google News RSS
- show headlines on homepage with links
- create dedicated News page for more headlines

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab3203f1483279dfa784fcba11bfc