### PR TITLE
Add sample scenario data and import it

### DIFF
--- a/src/data/sampleScenarios.json
+++ b/src/data/sampleScenarios.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "demo-1",
+    "name": "Electronics Import",
+    "hsCode": "8517.12",
+    "hsDescription": "Smartphones and mobile phones",
+    "fobValue": 25000,
+    "quantity": 500,
+    "shipping": 1200,
+    "insurance": 300,
+    "incoterm": "CIF"
+  },
+  {
+    "id": "demo-2",
+    "name": "Footwear Import",
+    "hsCode": "6403.91",
+    "hsDescription": "Sports footwear",
+    "fobValue": 15000,
+    "quantity": 300,
+    "shipping": 800,
+    "insurance": 150,
+    "incoterm": "FOB"
+  }
+]

--- a/src/pages/ScenarioComparerPage.tsx
+++ b/src/pages/ScenarioComparerPage.tsx
@@ -1,22 +1,11 @@
 import ScenarioComparer from '../components/ScenarioComparer';
-
-// Sample data structure matching the component's interface
-const sampleScenario = {
-  id: "demo-1",
-  name: "Electronics Import",
-  hsCode: "851712",
-  fobValue: 25000,
-  quantity: 500,
-  shipping: 1200,
-  insurance: 300,
-  incoterm: "CIF"
-};
+import sampleScenarios from '../data/sampleScenarios.json';
 
 export default function ScenarioPage() {
   return (
     <div className="container mx-auto p-4">
-      <ScenarioComparer 
-        initialScenarios={[sampleScenario]}
+      <ScenarioComparer
+        initialScenarios={[sampleScenarios[0]]}
         onEmailResults={() => {/* ... */}}
       />
     </div>


### PR DESCRIPTION
## Summary
- add example scenarios JSON file
- use JSON data in `ScenarioComparerPage`

## Testing
- `npm install` *(fails: integrity checksum issue)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ab3c07c9c8327846b628661b4c619