### PR TITLE
Add RSS-based news and dedicated News page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import Homepage from './pages/Homepage';
 import Calculator from './pages/Calculator';
+import News from './pages/News';
 import NewsletterModal from './components/NewsletterModal';
 
 function App() {
@@ -23,14 +24,7 @@ function App() {
           </div>
         );
       case 'news':
-        return (
-          <div className="min-h-screen pt-20 px-4">
-            <div className="max-w-4xl mx-auto py-12">
-              <h1 className="text-3xl font-bold text-gray-900 mb-8">Latest News</h1>
-              <p className="text-gray-600">News archive coming soon...</p>
-            </div>
-          </div>
-        );
+        return <News onNavigate={setCurrentPage} />;
       default:
         return <Homepage onNavigate={setCurrentPage} onShowNewsletter={() => setShowNewsletterModal(true)} />;
     }

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowRight, Newspaper, Calculator, BookOpen, Mail, Clock, ExternalLink } from 'lucide-react';
+import fetchRssNews from '../utils/fetchRssNews';
 
 interface HomepageProps {
   onNavigate: (page: string) => void;
@@ -23,25 +24,8 @@ const Homepage: React.FC<HomepageProps> = ({ onNavigate, onShowNewsletter }) => 
   useEffect(() => {
     const fetchNews = async () => {
       try {
-        const apiKey = import.meta.env.VITE_NEWS_API_KEY;
-        const response = await fetch(
-          `https://newsapi.org/v2/everything?q=trade%20tariff&sortBy=publishedAt&pageSize=5&apiKey=${apiKey}`
-        );
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch news');
-        }
-
-        const data = await response.json();
-        const articles = data.articles.map((a: any, index: number) => ({
-          id: a.url || String(index),
-          title: a.title,
-          source: a.source.name,
-          timestamp: new Date(a.publishedAt).toLocaleDateString(),
-          excerpt: a.description,
-          url: a.url,
-        }));
-        setNewsItems(articles);
+        const items = await fetchRssNews();
+        setNewsItems(items);
       } catch (err) {
         setError((err as Error).message);
       } finally {

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Clock, ExternalLink, Newspaper } from 'lucide-react';
+import fetchRssNews, { NewsItem } from '../utils/fetchRssNews';
+
+interface NewsPageProps {
+  onNavigate: (page: string) => void;
+}
+
+const News: React.FC<NewsPageProps> = ({ onNavigate }) => {
+  const [items, setItems] = useState<NewsItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchRssNews(undefined, 20);
+        setItems(data);
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen pt-20 px-4">
+      <div className="max-w-4xl mx-auto py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8 flex items-center">
+          <Newspaper className="h-8 w-8 text-teal-600 mr-2" />
+          Latest News
+        </h1>
+        {loading && <p className="text-center text-gray-500">Loading news...</p>}
+        {error && <p className="text-center text-red-600">{error}</p>}
+        <div className="space-y-8">
+          {!loading && !error &&
+            items.map((item) => (
+              <article key={item.id} className="border-b pb-6">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm text-teal-700">{item.source}</span>
+                  <div className="flex items-center text-sm text-gray-500">
+                    <Clock className="h-4 w-4 mr-1" />
+                    {item.timestamp}
+                  </div>
+                </div>
+                <h2 className="text-lg font-semibold">{item.title}</h2>
+                <p className="text-gray-600 mb-2">{item.excerpt}</p>
+                <a
+                  href={item.url}
+                  className="text-teal-700 text-sm flex items-center"
+                >
+                  Read more
+                  <ExternalLink className="ml-1 h-4 w-4" />
+                </a>
+              </article>
+            ))}
+        </div>
+        <div className="mt-8">
+          <button onClick={() => onNavigate('home')} className="text-teal-700">
+            ← Back to home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default News;

--- a/src/utils/fetchRssNews.ts
+++ b/src/utils/fetchRssNews.ts
@@ -1,0 +1,47 @@
+export interface NewsItem {
+  id: string;
+  title: string;
+  source: string;
+  timestamp: string;
+  excerpt: string;
+  url: string;
+}
+
+const DEFAULT_FEED =
+  'https://news.google.com/rss/search?q=vietnam%20us%20tariff&hl=en-US&gl=US&ceid=US:en';
+
+/**
+ * Fetch an RSS feed and return simplified news items.
+ * @param feedUrl RSS feed URL to fetch. Defaults to a Google News query on
+ *                Vietnam and US tariff topics.
+ * @param limit   Maximum number of items to return (defaults to 5)
+ */
+export default async function fetchRssNews(
+  feedUrl: string = DEFAULT_FEED,
+  limit = 5
+): Promise<NewsItem[]> {
+  const res = await fetch(feedUrl);
+  if (!res.ok) {
+    throw new Error('Failed to fetch RSS feed');
+  }
+  const xmlText = await res.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlText, 'application/xml');
+  const items = Array.from(doc.querySelectorAll('item')).slice(0, limit);
+  return items.map((item, idx) => {
+    const link = item.querySelector('link')?.textContent?.trim() ?? '';
+    return {
+      id:
+        item.querySelector('guid')?.textContent?.trim() ||
+        link ||
+        String(idx),
+      title: item.querySelector('title')?.textContent?.trim() ?? '',
+      source: new URL(link).hostname.replace('www.', '') || 'unknown',
+      timestamp: new Date(
+        item.querySelector('pubDate')?.textContent || Date.now()
+      ).toLocaleDateString(),
+      excerpt: item.querySelector('description')?.textContent?.trim() ?? '',
+      url: link,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- fetch RSS feed with `fetchRssNews` utility
- show RSS news on homepage
- implement dedicated `News` page
- update app routing to use new page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab79ca994832787daf5cd81313dc8